### PR TITLE
Add interactive price toggle button

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -293,6 +293,33 @@ header h1 {
     left: 0;
 }
 
+/* ===== Price Toggle ===== */
+.price-toggle-wrapper {
+    text-align: center;
+    margin-bottom: 20px;
+}
+
+.price-toggle-btn {
+    background-color: var(--primary-color);
+    color: var(--secondary-color);
+    border: none;
+    padding: 8px 20px;
+    border-radius: 20px;
+    font-size: 0.95em;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background-color 0.3s ease, transform 0.2s ease;
+}
+
+.price-toggle-btn:hover {
+    background-color: var(--accent-color);
+    transform: scale(1.05);
+}
+
+body.show-prices .price-toggle-btn {
+    background-color: var(--accent-color);
+}
+
 /* ===== Food Section ===== */
 .food {
     padding: 60px 0;

--- a/index.html
+++ b/index.html
@@ -115,6 +115,9 @@
             <div class="container">
                 <h2>Authentic Greek Cuisine</h2>
                 <p class="section-intro">Indulge in traditional Greek dishes prepared fresh throughout the festival</p>
+                <div class="price-toggle-wrapper">
+                    <button id="price-toggle" class="price-toggle-btn" onclick="document.body.classList.toggle('show-prices'); this.textContent = document.body.classList.contains('show-prices') ? 'Hide Prices' : 'Show Prices';">Show Prices</button>
+                </div>
 
                 <div class="food-categories">
                     <div class="food-category">


### PR DESCRIPTION
## Summary
Adds a "Show Prices / Hide Prices" toggle button to the food section, building on the hidden price spans from PR #2.

- Pill-shaped button centered above the menu categories
- Toggles `body.show-prices` class on click
- Button text updates dynamically ("Show Prices" ↔ "Hide Prices")
- Button color changes to accent red when prices are visible
- Zero dependencies — pure CSS + inline onclick handler

### How it works
The menu update PR (#2) embedded `<span class="food-price">$X</span>` on every item, hidden by default via `display: none`. This PR adds:
1. A toggle button that adds/removes `.show-prices` on `<body>`
2. CSS that styles the button and transitions its appearance

### Control options for Nina
- **Show toggle button**: Include the button HTML (default in this PR)
- **Always show prices**: Add `class="show-prices"` to `<body>` and remove the button
- **Never show prices**: Remove the button (prices stay hidden)

## Test plan
- [ ] Click "Show Prices" — all prices appear next to item names
- [ ] Click "Hide Prices" — prices disappear, button text reverts
- [ ] Button hover effect works (color change + slight scale)
- [ ] Mobile responsive — button stays centered and tappable

🤖 Generated with [Claude Code](https://claude.com/claude-code)