### PR TITLE
Move pastitsio photo from a la carte to dinner item

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Fort Wayne Greek Festival 2026 - Holy Trinity Greek Orthodox Church</title>
-    <link rel="stylesheet" href="css/style.css?v=1770347726">
+    <link rel="stylesheet" href="css/style.css?v=1770475154">
 </head>
 <body>
     <header>
@@ -149,14 +149,14 @@
                                 </div>
                             </div>
                             <div class="food-item">
-                                <div class="food-image-placeholder"></div>
+                                <div class="food-image" style="background-image: url('images/food/pastitsio_dinner.png');"></div>
                                 <div class="food-info">
                                     <strong>Pastitsio Dinner</strong> <span class="food-price">$16</span>
                                     <span class="food-desc">Greek lasagna: macaroni and seasoned ground beef with tomato-based Greek-herb sauce, topped with b&eacute;chamel and cheese, served with rice pilaf and a roll</span>
                                 </div>
                             </div>
                             <div class="food-item">
-                                <div class="food-image" style="background-image: url('images/food/pastitsio_dinner.png');"></div>
+                                <div class="food-image-placeholder"></div>
                                 <div class="food-info">
                                     <strong>Pastitsio &mdash; &agrave; la carte</strong> <span class="food-price">$13</span>
                                 </div>


### PR DESCRIPTION
Change made by the webmaster on the live site. The pastitsio_dinner.png image shows the dish served with sides (rice pilaf and a roll), which are included with the dinner but not the a la carte. Moved the photo to the Pastitsio Dinner item and reverted the a la carte to a placeholder.

https://claude.ai/code/session_01FyZjVdksApMMEKY88c1fs5