### PR TITLE
Add sponsor image placeholders wired to local image files

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -940,6 +940,20 @@ header {
     object-fit: contain;
 }
 
+.sponsor-logo-fallback {
+    display: none;
+    text-align: center;
+}
+
+.sponsor-logo-slot--missing {
+    border: 2px dashed #9db8d2;
+    background: #f4f8fc;
+}
+
+.sponsor-logo-slot--missing .sponsor-logo-fallback {
+    display: block;
+}
+
 .sponsor-logo-slot--feature {
     min-height: 130px;
 }

--- a/index.html
+++ b/index.html
@@ -539,14 +539,35 @@
                     <article class="sponsor-card sponsor-card--business">
                         <h4>Business Sponsors</h4>
                         <div class="business-sponsor-layout">
-                            <div class="business-composite-logo">Combined logo image</div>
+                            <div class="business-composite-logo sponsor-logo-slot sponsor-logo-slot--image sponsor-logo-slot--feature">
+                                <img class="sponsor-logo-image" src="images/sponsors/business-composite.png" alt="Business sponsors combined logo image" onerror="this.parentElement.classList.add('sponsor-logo-slot--missing'); this.style.display='none';">
+                                <span class="sponsor-logo-fallback">Add images/sponsors/business-composite.png</span>
+                            </div>
                             <div class="business-individual-logos" aria-label="Business sponsor logos">
-                                <div class="sponsor-logo-slot">Logo</div>
-                                <div class="sponsor-logo-slot">Logo</div>
-                                <div class="sponsor-logo-slot">Logo</div>
-                                <div class="sponsor-logo-slot">Logo</div>
-                                <div class="sponsor-logo-slot">Logo</div>
-                                <div class="sponsor-logo-slot">Logo</div>
+                                <div class="sponsor-logo-slot sponsor-logo-slot--image">
+                                    <img class="sponsor-logo-image" src="images/sponsors/business-01.png" alt="Business sponsor logo 1" onerror="this.parentElement.classList.add('sponsor-logo-slot--missing'); this.style.display='none';">
+                                    <span class="sponsor-logo-fallback">business-01.png</span>
+                                </div>
+                                <div class="sponsor-logo-slot sponsor-logo-slot--image">
+                                    <img class="sponsor-logo-image" src="images/sponsors/business-02.png" alt="Business sponsor logo 2" onerror="this.parentElement.classList.add('sponsor-logo-slot--missing'); this.style.display='none';">
+                                    <span class="sponsor-logo-fallback">business-02.png</span>
+                                </div>
+                                <div class="sponsor-logo-slot sponsor-logo-slot--image">
+                                    <img class="sponsor-logo-image" src="images/sponsors/business-03.png" alt="Business sponsor logo 3" onerror="this.parentElement.classList.add('sponsor-logo-slot--missing'); this.style.display='none';">
+                                    <span class="sponsor-logo-fallback">business-03.png</span>
+                                </div>
+                                <div class="sponsor-logo-slot sponsor-logo-slot--image">
+                                    <img class="sponsor-logo-image" src="images/sponsors/business-04.png" alt="Business sponsor logo 4" onerror="this.parentElement.classList.add('sponsor-logo-slot--missing'); this.style.display='none';">
+                                    <span class="sponsor-logo-fallback">business-04.png</span>
+                                </div>
+                                <div class="sponsor-logo-slot sponsor-logo-slot--image">
+                                    <img class="sponsor-logo-image" src="images/sponsors/business-05.png" alt="Business sponsor logo 5" onerror="this.parentElement.classList.add('sponsor-logo-slot--missing'); this.style.display='none';">
+                                    <span class="sponsor-logo-fallback">business-05.png</span>
+                                </div>
+                                <div class="sponsor-logo-slot sponsor-logo-slot--image">
+                                    <img class="sponsor-logo-image" src="images/sponsors/business-06.png" alt="Business sponsor logo 6" onerror="this.parentElement.classList.add('sponsor-logo-slot--missing'); this.style.display='none';">
+                                    <span class="sponsor-logo-fallback">business-06.png</span>
+                                </div>
                             </div>
                         </div>
                     </article>
@@ -661,4 +682,3 @@
     </footer>
 </body>
 </html>
-


### PR DESCRIPTION
### Motivation
- The issue images referenced in Issue #28 cannot be reliably fetched at runtime, so sponsor assets should be consumed from the repo instead. 
- Make the Business Sponsors area ready to display approved sponsor images dropped into a local `images/sponsors/` folder and avoid broken image icons while files are added incrementally.

### Description
- Replaced the Business Sponsors placeholder boxes with `<img>` slots pointing at `images/sponsors/business-composite.png` and `images/sponsors/business-01.png` through `images/sponsors/business-06.png`. 
- Added `onerror` handlers to hide broken `<img>` elements and add a `.sponsor-logo-slot--missing` state so a readable filename fallback is shown. 
- Added a fallback `<span>` (`.sponsor-logo-fallback`) in each slot and updated CSS (`css/style.css`) to display the fallback text when an image is missing. 
- Kept existing band/menu sponsor logos unchanged and preserved styling for feature slots.

### Testing
- Verified the file changes and diff with `git status` and `git diff -- css/style.css index.html | sed -n '1,240p'`, which reported the intended modifications. 
- Inspected the modified regions with `nl -ba index.html | sed -n '534,595p'` and `nl -ba css/style.css | sed -n '932,970p'` to confirm the added HTML and CSS were present. 
- Created the pull request using the repository tooling (`mcp__make_pr__make_pr`) and the PR metadata was generated successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd4a28cf6c8327b504bb621b936fb0)